### PR TITLE
fix: clear semantic tokens cache on document open/close to prevent st…

### DIFF
--- a/Catglobe.CgScript.EditorSupport.Lsp/Handlers/CgScriptLanguageTarget.cs
+++ b/Catglobe.CgScript.EditorSupport.Lsp/Handlers/CgScriptLanguageTarget.cs
@@ -104,15 +104,18 @@ public partial class CgScriptLanguageTarget
 
    public void OnDidOpen(DidOpenTextDocumentParams p)
    {
+      var uri = p.TextDocument.Uri.ToString();
       try
       {
-         _store.Update(p.TextDocument.Uri.ToString(), p.TextDocument.Text);
+         _store.Update(uri, p.TextDocument.Text);
       }
       catch (Exception ex)
       {
          _ = PublishErrorDiagnosticAsync(p.TextDocument.Uri, ex);
          return;
       }
+      // Clear semantic cache to force full semantic tokens request on first access
+      _semanticCache.TryRemove(uri, out _);
       _ = PublishDiagnosticsAsync(p.TextDocument.Uri);
    }
 
@@ -139,7 +142,9 @@ public partial class CgScriptLanguageTarget
 
    public void OnDidClose(DidCloseTextDocumentParams p)
    {
-      _store.Remove(p.TextDocument.Uri.ToString());
+      var uri = p.TextDocument.Uri.ToString();
+      _store.Remove(uri);
+      _semanticCache.TryRemove(uri, out _);
       _ = Rpc?.NotifyWithParameterObjectAsync(Methods.TextDocumentPublishDiagnosticsName,
          new PublishDiagnosticParams { Uri = p.TextDocument.Uri, Diagnostics = [] });
    }


### PR DESCRIPTION
…ale syntax highlighting

Problem:

When a .cgs file had syntax errors, the semantic tokens were cached with incorrect token data. After fixing the errors and reopening the file, Visual Studio would sometimes request incremental delta updates using the stale previousResultId, causing the delta logic to compute tokens based on the old cached data. This resulted in persistent incorrect syntax coloring even though the code was now valid.

Root Cause:

The semantic tokens cache (_semanticCache) was never cleared when documents were opened or closed. When reopening a file, if VS retained the old resultId and requested a delta update, the server would use stale cached data to compute the delta, propagating the incorrect coloring.

Solution:

1. Clear semantic cache in OnDidOpen() - Forces VS to request full semantic tokens on file open, ensuring fresh token data is computed from the current parse result

2. Clear semantic cache in OnDidClose() - Cleanup memory and prevent stale cache from being reused

Impact:

- Syntax highlighting now correctly updates when files are reopened after fixing errors

- No performance impact during typing - delta optimization still works during active editing

- Minimal code change - only two cache invalidation calls added

Testing:

1. Open a .cgs file with syntax errors

2. Note the incorrect syntax highlighting

3. Fix the errors

4. Close and reopen the file

5. Verify syntax highlighting is now correct